### PR TITLE
Add a custom recipe to add endspeed to a shuriken

### DIFF
--- a/scripts/tinker-endspeed-modifier.zs
+++ b/scripts/tinker-endspeed-modifier.zs
@@ -14,59 +14,59 @@ import mods.jei.JEI;
 // The properties/cost of the modifier.
 static modifierCost as short = 1;
 static modifierItems as IIngredient[] = [
-   <minecraft:end_rod>,
-   <minecraft:ender_pearl>,
-   <minecraft:nether_star>,
-   <enderio:item_alloy_ingot:8>, // end steel ingot
+	<minecraft:end_rod>,
+	<minecraft:ender_pearl>,
+	<minecraft:nether_star>,
+	<enderio:item_alloy_ingot:8>, // end steel ingot
 ];
 static modifierName as string = "endspeed"; // Also the trait name.
 static modifierData as IData = {
-   identifier: modifierName,
-   color: -1507370,
-   level: 1,
+	identifier: modifierName,
+	color: -1507370,
+	level: 1,
 };
 
 // Create a custom item in JEI for this modifier.
 static modifierItem as IItemStack = <minecraft:end_rod>.withTag({
-   display: {
-      Name: "Endspeed Modifier",
-      Lore: [
-         "Adds the Endspeed modifier to a shuriken.",
-         "Use in a crafting table, not a tool station/forge.",
-      ],
-   },
+	display: {
+		Name: "Endspeed Modifier",
+		Lore: [
+			"Adds the Endspeed modifier to a shuriken.",
+			"Use in a crafting table, not a tool station/forge.",
+		],
+	},
 });
 JEI.addItem(modifierItem);
 JEI.addDescription(modifierItem, [
-   "This special end rod can be combined with a shuriken in a crafting table to add the endspeed modifier to the shuriken, at the cost of 1 modifier slot.",
-   "(Note that this has to be the 'Endspeed Modifier' item, not a regular end rod.)",
+	"This special end rod can be combined with a shuriken in a crafting table to add the endspeed modifier to the shuriken, at the cost of 1 modifier slot.",
+	"(Note that this has to be the 'Endspeed Modifier' item, not a regular end rod.)",
 ]);
 recipes.addShapeless(modifierItem, modifierItems);
 
 // Finally, add a recipe that combines any shuriken with the special modifier item, and that actually adds the modifier
 // to the shuriken.
 recipes.addShapeless(<tconstruct:shuriken>, [<tconstruct:shuriken>.anyDamage().marked("shuriken"), modifierItem], function (out, ins, cInfo) {
-   var freeModifiers = ins.shuriken.tag.memberGet("Stats").memberGet("FreeModifiers");
-   var modifierNameList = ins.shuriken.tag.memberGet("TinkerData").memberGet("Modifiers");
+	var freeModifiers = ins.shuriken.tag.memberGet("Stats").memberGet("FreeModifiers");
+	var modifierNameList = ins.shuriken.tag.memberGet("TinkerData").memberGet("Modifiers");
 
-   // If there are no free modifiers this recipe cannot be used.
-   if (freeModifiers < modifierCost) {
-      return null;
-   }
+	// If there are no free modifiers this recipe cannot be used.
+	if (freeModifiers < modifierCost) {
+		return null;
+	}
 
-   // If the item already has this modifier this recipe also cannot be used.
-   if (modifierNameList has modifierName) {
-      return null;
-   }
+	// If the item already has this modifier this recipe also cannot be used.
+	if (modifierNameList has modifierName) {
+		return null;
+	}
 
-   return ins.shuriken.withTag(ins.shuriken.tag + {
-      Stats: {
-         FreeModifiers: freeModifiers - modifierCost,
-      },
-      Modifiers: [modifierData],
-      TinkerData: {
-         Modifiers: [modifierName],
-      },
-      Traits: [modifierName],
-   });
+	return ins.shuriken.withTag(ins.shuriken.tag + {
+		Stats: {
+			FreeModifiers: freeModifiers - modifierCost,
+		},
+		Modifiers: [modifierData],
+		TinkerData: {
+			Modifiers: [modifierName],
+		},
+		Traits: [modifierName],
+	});
 } as IRecipeFunction);

--- a/scripts/tinker-endspeed-modifier.zs
+++ b/scripts/tinker-endspeed-modifier.zs
@@ -1,0 +1,72 @@
+/*
+ * This makes it possible to add the endspeed modifier to shuriken, because it's just too much fun to not be available.
+ * Because it's not possible to add this as a modifier that can be applied in the tool forge, it's instead done in a
+ * regular crafting grid, but it otherwise behaves the same way (uses a modifier slot, not available if there is no free
+ * slot, etc).
+ */
+
+import crafttweaker.data.IData;
+import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemStack;
+import crafttweaker.recipes.IRecipeFunction;
+import mods.jei.JEI;
+
+// The properties/cost of the modifier.
+static modifierCost as short = 1;
+static modifierItems as IIngredient[] = [
+   <minecraft:end_rod>,
+   <minecraft:ender_pearl>,
+   <minecraft:nether_star>,
+   <enderio:item_alloy_ingot:8>, // end steel ingot
+];
+static modifierName as string = "endspeed"; // Also the trait name.
+static modifierData as IData = {
+   identifier: modifierName,
+   color: -1507370,
+   level: 1,
+};
+
+// Create a custom item in JEI for this modifier.
+static modifierItem as IItemStack = <minecraft:end_rod>.withTag({
+   display: {
+      Name: "Endspeed Modifier",
+      Lore: [
+         "Adds the Endspeed modifier to a shuriken.",
+         "Use in a crafting table, not a tool station/forge.",
+      ],
+   },
+});
+JEI.addItem(modifierItem);
+JEI.addDescription(modifierItem, [
+   "This special end rod can be combined with a shuriken in a crafting table to add the endspeed modifier to the shuriken, at the cost of 1 modifier slot.",
+   "(Note that this has to be the 'Endspeed Modifier' item, not a regular end rod.)",
+]);
+recipes.addShapeless(modifierItem, modifierItems);
+
+// Finally, add a recipe that combines any shuriken with the special modifier item, and that actually adds the modifier
+// to the shuriken.
+recipes.addShapeless(<tconstruct:shuriken>, [<tconstruct:shuriken>.anyDamage().marked("shuriken"), modifierItem], function (out, ins, cInfo) {
+   var freeModifiers = ins.shuriken.tag.memberGet("Stats").memberGet("FreeModifiers");
+   var modifierNameList = ins.shuriken.tag.memberGet("TinkerData").memberGet("Modifiers");
+
+   // If there are no free modifiers this recipe cannot be used.
+   if (freeModifiers < modifierCost) {
+      return null;
+   }
+
+   // If the item already has this modifier this recipe also cannot be used.
+   if (modifierNameList has modifierName) {
+      return null;
+   }
+
+   return ins.shuriken.withTag(ins.shuriken.tag + {
+      Stats: {
+         FreeModifiers: freeModifiers - modifierCost,
+      },
+      Modifiers: [modifierData],
+      TinkerData: {
+         Modifiers: [modifierName],
+      },
+      Traits: [modifierName],
+   });
+} as IRecipeFunction);


### PR DESCRIPTION
We spoke about making endspeed available to shuriken again, originally talking about maybe adding it to a specific material. I played around with this a bit and ended up going a different route, instead making it available as a modifier that you can add to any shuriken. This makes it more versatile, and allowed me to play around with some CraftTweaker stuff that we hadn't used yet.

This adds a custom item in JEI (really just an end rod with some extra metadata), with the appropriate documentation. JEI unfortunately shows this documentation on the regular end rod as well, so I added a note emphasizing that the note regards the special end rod.

This item can be combined with any shuriken in a regular crafting table to add the endspeed modifier to the shuriken. This costs 1 modifier slot, and is not usable if the shuriken doesn't have a free modifier. It can also only be applied once. I would have preferred for it to be done in the tool station/forge like other modifiers, but it doesn't seem like that's possible with CT, so I settled for making it at least behave like applying other modifiers.

The cost for this item is 1 regular end rod (which is the material that normally has the endspeed modifier when used for arrows and bolts), 1 ender pearl, 1 end steel ingot, and 1 nether star. Pretty much just some end-related stuff and a nether star. This makes it gated behind The End, gated behind a little bit of EnderIO, and somewhat expensive. Ideas/suggestions wrt balancing this are very welcome.